### PR TITLE
Pack task

### DIFF
--- a/Marlin/src/configuration.h
+++ b/Marlin/src/configuration.h
@@ -23,7 +23,7 @@
 #define MODULES_WHIMSYCWD_MARLIN_SRC_CONFIGURATION_H_
 
 #include <stdint.h>
-#define APP_VERSIONS "v1.9.1"
+#define APP_VERSIONS "v1.9.3"
 #define FLASH_BASE 0x8000000
 
 #define FLASH_PAGE_COUNT (128)

--- a/Marlin/src/module/enclosure.cpp
+++ b/Marlin/src/module/enclosure.cpp
@@ -60,8 +60,9 @@ void EnclosureModule::StartingUpLight() {
     time = millis() + 3;
     if (start_flag_ == 1) {
       out += 1;
-      if (out == 200) {
-        start_flag_ = 2;
+      if (out == 255) {
+        start_flag_ = 0
+        ;
       }
     } else if (start_flag_ == 2) {
       out -= 1;

--- a/snapmaker/scripts/platformio-targets.py
+++ b/snapmaker/scripts/platformio-targets.py
@@ -53,6 +53,6 @@ env.AddCustomTarget(
     actions=[
     "python {0} -d {1} -m {2} ".format(pack_script, project_dir, fw_bin),
     ],
-    title="Core Env",
-    description="Show PlatformIO Core and Python versions"
+    title="Pack",
+    description="Pack Snapmaker Firmware"
 )


### PR DESCRIPTION
This changes the PlatformIO task name from the default of "Core Env" to something readily searchable, "Pack"

New name can be searched in the list of tasks:
![image](https://user-images.githubusercontent.com/7025732/103423788-73b1b580-4b5d-11eb-8dc8-d78457a65145.png)


Previously it showed up only as this:
![image](https://user-images.githubusercontent.com/7025732/103423741-22092b00-4b5d-11eb-878b-a59177becade.png)
