### PR TITLE
Don't use sprintf

### DIFF
--- a/Marlin/src/registry/registry.cpp
+++ b/Marlin/src/registry/registry.cpp
@@ -222,15 +222,17 @@ void Registry::ReportVersions(uint8_t * data) {
   AppParmInfo * app_parm = (AppParmInfo *)FLASH_APP_PARA;
 
   versions[index++] = CMD_S_VERSIONS_REACK;
+  const char *version;
   if (data[0] == 0) {
     versions[index++] = 0;
-    sprintf((char *)(versions + index), "%s", (char *)APP_VERSIONS);
-    index += strlen(APP_VERSIONS);
+    version = APP_VERSIONS;
   } else {
     versions[index++] = 1;
-    sprintf((char *)(versions + index), "%s", (char *)app_parm->versions);
-    index += strlen((char *)app_parm->versions);
+    version = reinterpret_cast<const char*>(app_parm->versions);
   }
+  size_t length = strlen(version);
+  memcpy(versions + index, version, length);
+  index += length;
   longpackInstance.sendLongpack(versions, index);
 }
 


### PR DESCRIPTION
The code uses `sprintf(..., "%s", ...);` to copy a string and then directly calculates the length of this string. This is just ridiculously inefficient: `sprintf` returns the number of bytes anyway, so the return value could be used instead of using `strlen`, but on a much more fundamental note `sprintf` is way more powerful than required for such a usecase. It has to parse the format string which is both relatively slow and introduces flash overhead since it happens at runtime and therefore unneeded branches can't be omitted. Additionally it sometimes uses a more flexible but slower memory copy implementation. (Not that that would really matter for upto 32bytes).

Here I used `memcpy` instead of `strcpy` since the length has to be calculated anyway. The final NULL byte is not copied since it isn't sent anyway.  With my compiler, this reduces the flash size of the firmware by **more than 30%** (from 51456 bytes to 35496 bytes). *Like the original code, it does not check the length and assumes that the version fields never exceed 31 bytes.*